### PR TITLE
Added numba to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+numba==0.48
 librosa>=0.7.2
 matplotlib>=3.2.1


### PR DESCRIPTION
The current version of librosa doesn't specify properly their numba dependency, leading it to errors. As stated here:
https://github.com/librosa/librosa/issues/1160
While the fix them we could pin the proper numba version to make sure the app works